### PR TITLE
Fixed numpy slice error due to division creating a float

### DIFF
--- a/frequency_monitors/show_freq_monitor.py
+++ b/frequency_monitors/show_freq_monitor.py
@@ -61,7 +61,7 @@ def transform_field(field, metadata, npoints, apodization_func=None):
 
     fft_field = abs(np.fft.fft(field, n=n_sample_points, axis=-1).real)
     fft_field = fft_field[:, :, :fft_field.shape[-1]//2]
-    freqs = np.fft.fftfreq(n_sample_points, d=dt)[:(n_sample_points/2)]
+    freqs = np.fft.fftfreq(n_sample_points, d=dt)[:(int(n_sample_points/2))]
 
     # We are only interested on the frequencies inside the source bandwidth
     mask = (freqs >= min_freq) * (freqs <= max_freq)


### PR DESCRIPTION
Numpy complains that the number is not an int due to division by 2 creating a float, even if the number is even. Fixed by forcing it to be an int.